### PR TITLE
Fixes wong key in sample vault backend configuration

### DIFF
--- a/setup/configuration/index.md
+++ b/setup/configuration/index.md
@@ -64,7 +64,7 @@ spring:
           port: 8200
           backend: secret
           kvVersion: 2
-          default-key: clouddriver
+          defaultKey: clouddriver
           token: [vault access token]
 ```
 


### PR DESCRIPTION
This pr replaces the wrong key in the sample code block for configuring vault backend 

[Docs](https://cloud.spring.io/spring-cloud-static/spring-cloud-config/2.2.1.RELEASE/reference/html/#vault-backend)
closes #1728